### PR TITLE
Optische Anpassung der Navbar

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -29,6 +29,7 @@ import {
   NAV_DISCORD_LINK,
   NAV_MEGA_MENU_SECTIONS,
   NAV_PRIMARY_LINKS,
+  NAV_SOCIAL_LINKS,
   type NavMenuIcon,
 } from '../data/nav';
 import { appRoutes } from '../config/routes';
@@ -121,56 +122,47 @@ const linkClassMega = (active: boolean) =>
         }
       </nav>
 
-      <div class="site-nav-controls relative flex min-w-0 items-center gap-2">
-        <IconButton ariaLabel="Theme wechseln" data-theme-toggle>
+      <div class="site-nav-controls relative flex min-w-0 items-center">
+        <div class="site-nav-socials hidden items-center gap-1 lg:flex" aria-label="Social Links">
+          {
+            NAV_SOCIAL_LINKS.map((item) => (
+              <NavItem
+                href={item.href}
+                external={item.external}
+                ariaLabel={item.label}
+                showExternalHint={false}
+                class="site-nav-social-link"
+              >
+                <svg viewBox="0 0 127.14 96.36" aria-hidden="true">
+                  <path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z" />
+                </svg>
+                <span class="sr-only">{item.label}</span>
+              </NavItem>
+            ))
+          }
+        </div>
+
+        <span class="site-nav-separator hidden lg:block" aria-hidden="true"></span>
+
+        <IconButton
+          ariaLabel="Theme wechseln"
+          variant="plain"
+          class="site-nav-control-button"
+          data-theme-toggle
+        >
           <Sun size={18} class="hidden" data-theme-icon="light" />
           <Moon size={18} class="hidden" data-theme-icon="dark" />
           <SunMoon size={18} data-theme-icon="system" />
         </IconButton>
 
-        <!-- Discord-Status (Desktop) + Hover-Card -->
-        <div class="group relative hidden lg:inline-block">
-          <div tabindex="0" aria-label="Discord Status" class="site-discord-link">
-            <span class="site-discord-icon" aria-hidden="true">
-              <svg viewBox="0 0 127.14 96.36" class="h-5 w-5 fill-current">
-                <path
-                  d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"
-                ></path>
-              </svg>
-            </span>
-            <span class="site-discord-text">
-              <span class="mg-discord-members tabular-nums" data-discord-members>-</span>
-              <span class="site-discord-label">Mitglieder</span>
-            </span>
-          </div>
-
-          <div
-            class="invisible absolute top-full right-0 left-auto z-50 mt-2 w-[min(15rem,calc(100vw-1.5rem))] translate-y-1 opacity-0 transition-all duration-150 group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:opacity-100 group-hover:visible group-hover:translate-y-0 group-hover:opacity-100"
-          >
-            <div class="site-nav-solid-card mg-card mg-card--raised rounded-[var(--radius)] p-4">
-              <div class="text-sm font-semibold">Discord Status</div>
-              <div class="mt-3 flex items-center justify-between text-sm">
-                <span class="text-muted">Mitglieder:</span>
-                <span class="font-semibold tabular-nums" data-discord-members>-</span>
-              </div>
-              <div class="mt-3">
-                <NavItem
-                  href={NAV_DISCORD_LINK.href}
-                  external
-                  class="text-accent hover:text-accent2 hover:decoration-accent/60 text-sm font-semibold whitespace-nowrap underline decoration-transparent underline-offset-4 transition-colors"
-                >
-                  Discord beitreten
-                </NavItem>
-              </div>
-            </div>
-          </div>
-        </div>
+        <span class="site-nav-separator" aria-hidden="true"></span>
 
         <IconButton
           ariaLabel="Menü öffnen"
           aria-controls="nav-panel"
           aria-expanded="false"
-          class="site-nav-toggle shrink-0"
+          variant="plain"
+          class="site-nav-toggle site-nav-control-button shrink-0"
           data-nav-toggle
         >
           <span class="site-nav-toggle-icon" aria-hidden="true">

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -7,6 +7,12 @@ export type NavLink = {
   external?: boolean;
 };
 
+export type NavSocialIcon = 'discord';
+
+export type NavSocialLink = NavLink & {
+  icon: NavSocialIcon;
+};
+
 export type NavMenuIcon =
   | 'home'
   | 'tutorial'
@@ -57,6 +63,8 @@ export const NAV_DISCORD_LINK: NavLink = {
   label: 'Discord',
   external: true,
 };
+
+export const NAV_SOCIAL_LINKS: NavSocialLink[] = [{ ...NAV_DISCORD_LINK, icon: 'discord' }];
 
 export const NAV_MEGA_MENU_SECTIONS: NavMenuSection[] = [
   {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -321,7 +321,78 @@
   }
 
   .site-nav-controls {
+    gap: 0.35rem;
     min-width: 0;
+  }
+
+  .site-nav-social-link,
+  .site-nav-controls .site-nav-control-button {
+    --site-nav-icon-color: rgb(255 255 255 / 0.9);
+    --site-nav-icon-hover: var(--accent);
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+    border-radius: 0.65rem;
+    color: var(--site-nav-icon-color);
+    text-decoration: none;
+    background: transparent;
+    box-shadow: none;
+    transition:
+      color 150ms ease,
+      background-color 150ms ease;
+  }
+
+  .site-nav-social-link svg {
+    width: 1.18rem;
+    height: 1.18rem;
+    fill: currentColor;
+  }
+
+  .site-nav-social-link:hover,
+  .site-nav-controls .site-nav-control-button:hover {
+    color: var(--site-nav-icon-hover);
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .site-nav-social-link:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 3px;
+  }
+
+  .site-nav-separator {
+    display: block;
+    flex: 0 0 0;
+    width: 0;
+    height: 2rem;
+    margin-inline: 0.25rem;
+    border-left: 1px solid rgb(255 255 255 / 0.14);
+    background: transparent;
+  }
+
+  html[data-theme='light'] .site-nav-social-link,
+  html[data-theme='light'] .site-nav-controls .site-nav-control-button {
+    --site-nav-icon-color: color-mix(in oklab, var(--fg) 76%, transparent);
+  }
+
+  html[data-theme='light'] .site-nav-separator {
+    border-left-color: color-mix(in oklab, var(--fg) 18%, transparent);
+  }
+
+  @media (prefers-color-scheme: light) {
+    html:not([data-theme='dark']) .site-nav-social-link,
+    html:not([data-theme='dark']) .site-nav-controls .site-nav-control-button {
+      --site-nav-icon-color: color-mix(in oklab, var(--fg) 76%, transparent);
+    }
+
+    html:not([data-theme='dark']) .site-nav-separator {
+      border-left-color: color-mix(in oklab, var(--fg) 18%, transparent);
+    }
   }
 
   .site-nav-toggle {
@@ -395,69 +466,6 @@
     box-shadow:
       inset 0 1px 0 color-mix(in oklab, var(--glass-highlight) 50%, transparent),
       0 14px 30px -24px color-mix(in oklab, var(--fg) 36%, transparent);
-  }
-
-  .site-discord-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.34rem;
-    height: 2.5rem;
-    min-height: 2.5rem;
-    min-inline-size: 8.9rem;
-    padding: 0 0.56rem;
-    max-inline-size: min(15rem, calc(100vw - 7rem));
-    border-radius: 0.7rem;
-    border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border) 72%);
-    background: color-mix(in oklab, var(--surface-solid) 16%, transparent);
-    color: color-mix(in oklab, var(--fg) 92%, transparent);
-    text-decoration: none;
-    line-height: 1;
-    font-size: 0.84rem;
-    font-weight: 650;
-    overflow: hidden;
-    cursor: default;
-    transition:
-      color 150ms ease,
-      background-color 150ms ease,
-      border-color 150ms ease,
-      box-shadow 150ms ease;
-  }
-
-  .site-discord-text {
-    display: inline-flex;
-    gap: 0.24rem;
-    min-width: 0;
-    align-items: center;
-  }
-
-  .site-discord-link:hover {
-    color: var(--fg);
-    border-color: color-mix(in oklab, var(--accent) 44%, var(--border) 56%);
-    background: color-mix(in oklab, var(--surface-solid) 30%, transparent);
-    box-shadow: 0 10px 18px -18px color-mix(in oklab, var(--fg) 65%, transparent);
-  }
-
-  .site-discord-link:focus-visible {
-    outline: 2px solid var(--ring);
-    outline-offset: 3px;
-  }
-
-  .site-discord-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.28rem;
-    height: 1.28rem;
-    color: color-mix(in oklab, var(--fg) 90%, transparent);
-    flex: none;
-  }
-
-  .site-discord-label {
-    color: color-mix(in oklab, var(--fg) 88%, transparent);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   /* Projekt-Designsystem-Aliasse ("mg" = Minecraft Gilde). */
@@ -1470,17 +1478,6 @@
     user-select: none;
     background: color-mix(in oklab, var(--surface-solid) 55%, var(--fg) 45%);
     animation: mg-counter-pulse 1.25s ease-in-out infinite;
-  }
-
-  /* Navbar-Counter im Discord-Button: kompakt, ohne kuenstliche Ziffernspalte. */
-  .mg-discord-members {
-    display: inline-block;
-    white-space: nowrap;
-  }
-
-  .mg-discord-members.mg-live-counter[data-live-state='loading'] {
-    min-width: 0;
-    padding-inline: 0;
   }
 
   .mg-live-counter[data-live-state='error'] {


### PR DESCRIPTION
Rechts ist kein breiter Discord-Status-Pill mehr, der visuell mit den Hauptlinks konkurriert. Die Navbar wirkt dadurch mehr wie eine moderne Site-Navigation und weniger wie eine Mischung aus Navigation und Live-Dashboard. Discord als Icon ist sofort erkennbar, aber nicht dominant.